### PR TITLE
Replaced placeholder GUID with correct one

### DIFF
--- a/Jellyfin.Plugin.Template/Configuration/configPage.html
+++ b/Jellyfin.Plugin.Template/Configuration/configPage.html
@@ -42,7 +42,7 @@
         </div>
         <script type="text/javascript">
             var TemplateConfig = {
-                pluginUniqueId: 'eb5d7894-8eef-4b36-aa6f-5d124e828ce1'
+                pluginUniqueId: '134f71b5-69ef-44f9-9473-745e71720148'
             };
 
             document.querySelector('#TemplateConfigPage')


### PR DESCRIPTION
In the HTML template we were still using the placeholder GUID. This has been replaced with the plugin GUID.