### PR TITLE
Created a factory for JellybenchManagerService

### DIFF
--- a/Jellyfin.Plugin.Template/Api/JellybenchApiController.cs
+++ b/Jellyfin.Plugin.Template/Api/JellybenchApiController.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using Jellyfin.Plugin.Template.Factories;
 using Jellyfin.Plugin.Template.Services.JellybenchManager;
 using Microsoft.AspNetCore.Mvc;
 
@@ -20,10 +21,10 @@ namespace Jellyfin.Plugin.Template.Controller
         /// <summary>
         /// Initializes a new instance of the <see cref="JellybenchApiController"/> class.
         /// </summary>
-        /// <param name="jellybenchManagerService">Jellyfin benchmark service.</param>
-        public JellybenchApiController(IJellybenchManagerService jellybenchManagerService)
+        /// <param name="serviceProvider">Jellyfin benchmark service.</param>
+        public JellybenchApiController(IServiceProvider serviceProvider)
         {
-            _jellybenchManagerService = jellybenchManagerService;
+            _jellybenchManagerService = new JellybenchManagerFactory(serviceProvider).Create();
         }
 
         /// <summary>

--- a/Jellyfin.Plugin.Template/Factories/JellybenchManagerFactory.cs
+++ b/Jellyfin.Plugin.Template/Factories/JellybenchManagerFactory.cs
@@ -1,0 +1,37 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Jellyfin.Plugin.Template.Services.JellybenchManager;
+using MediaBrowser.Model.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Jellyfin.Plugin.Template.Factories
+{
+    /// <summary>
+    /// Factory to create the <see cref="JellybenchManagerService"/>.
+    /// </summary>
+    public class JellybenchManagerFactory
+    {
+        private readonly IServiceProvider _serviceProvider;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="JellybenchManagerFactory"/> class.
+        /// </summary>
+        /// <param name="serviceProvider">Service provider.</param>
+        public JellybenchManagerFactory(IServiceProvider serviceProvider)
+        {
+            _serviceProvider = serviceProvider;
+        }
+
+        /// <summary>
+        /// Creates the JellybenchManagerService.
+        /// </summary>
+        /// <returns>JellybenchManagerService.</returns>
+        public JellybenchManagerService Create()
+        {
+            return new JellybenchManagerService(_serviceProvider.GetRequiredService<ITaskManager>());
+        }
+    }
+}


### PR DESCRIPTION
This factory can be used in places where the service cannot be injected directly. For example, in the JellybenchApiController, which only works with Jellyfin's and build in services.