### PR TITLE
[Discussion] Added post build event for convenience

### DIFF
--- a/Jellyfin.Plugin.Template/Jellyfin.Plugin.Template.csproj
+++ b/Jellyfin.Plugin.Template/Jellyfin.Plugin.Template.csproj
@@ -26,4 +26,8 @@
     <EmbeddedResource Include="Configuration\configPage.html" />
   </ItemGroup>
 
+  <Target Name="PostBuild" AfterTargets="PostBuildEvent">
+    <Exec Command="xcopy &quot;$(ProjectDir)\bin\Debug\net6.0&quot; &quot;%25LocalAppData%25\jellyfin\plugins\Jellybench\&quot; /Y /I" />
+  </Target>
+
 </Project>


### PR DESCRIPTION
It copies the build debug dll's to the Jellyfin plugin jellybench folder in local appdata so that jellyfin can load the plugin.